### PR TITLE
refactor: separar rutas y servicio de chat

### DIFF
--- a/simple-graphchain/chat-router.ts
+++ b/simple-graphchain/chat-router.ts
@@ -1,0 +1,37 @@
+import { Router, type Request, type Response } from "express";
+import {
+  EmptyAIResponseError,
+  type ChatService,
+} from "./chat-service.js";
+
+export function createChatRouter(chatService: ChatService) {
+  const router = Router();
+
+  router.post("/", async (req: Request, res: Response) => {
+    const validation = chatService.validate(req.body);
+
+    if (!validation.success) {
+      res
+        .status(400)
+        .json({ error: "Solicitud inválida", details: validation.errors });
+      return;
+    }
+
+    try {
+      const content = await chatService.createChatCompletion(validation.data);
+      res.json({ content });
+    } catch (error) {
+      if (error instanceof EmptyAIResponseError) {
+        res.status(502).json({ error: error.message });
+        return;
+      }
+
+      console.error("Error al invocar el modelo:", error);
+      res.status(500).json({
+        error: "No se pudo obtener una respuesta de la IA.",
+      });
+    }
+  });
+
+  return router;
+}

--- a/simple-graphchain/chat-service.ts
+++ b/simple-graphchain/chat-service.ts
@@ -1,0 +1,136 @@
+import { AIMessage, HumanMessage, SystemMessage, type BaseMessage } from "@langchain/core/messages";
+import { z } from "zod";
+import { createGroqClient, type GroqChatModel } from "./groq-client.js";
+
+const messageSchema = z.object({
+  role: z.enum(["user", "assistant", "system"]).default("user"),
+  content: z.string().min(1, "El contenido no puede estar vacío."),
+});
+
+const chatPayloadSchema = z.object({
+  messages: z.array(messageSchema).min(1, "Se requiere al menos un mensaje."),
+});
+
+export type ChatPayload = z.infer<typeof chatPayloadSchema>;
+
+export type ChatValidationResult =
+  | { success: true; data: ChatPayload }
+  | { success: false; errors: string[] };
+
+export class EmptyAIResponseError extends Error {
+  constructor(message = "La respuesta de la IA está vacía.") {
+    super(message);
+    this.name = "EmptyAIResponseError";
+  }
+}
+
+export interface ChatService {
+  validate(payload: unknown): ChatValidationResult;
+  createChatCompletion(payload: ChatPayload): Promise<string>;
+}
+
+type ChatModel = Pick<GroqChatModel, "invoke">;
+
+interface ChatServiceDependencies {
+  model: ChatModel;
+  systemPrompt?: string;
+}
+
+export function validateChatPayload(payload: unknown): ChatValidationResult {
+  const parsed = chatPayloadSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    const errors = parsed.error.issues.map((issue) => issue.message);
+    return { success: false, errors };
+  }
+
+  return { success: true, data: parsed.data };
+}
+
+function toLangChainMessages(
+  messages: ChatPayload["messages"],
+  systemPrompt?: string
+) {
+  const formatted: BaseMessage[] = [];
+
+  if (systemPrompt) {
+    formatted.push(new SystemMessage(systemPrompt));
+  }
+
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      formatted.push(new AIMessage(message.content));
+      continue;
+    }
+
+    if (message.role === "system") {
+      formatted.push(new SystemMessage(message.content));
+      continue;
+    }
+
+    formatted.push(new HumanMessage(message.content));
+  }
+
+  return formatted;
+}
+
+function extractContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === "string") {
+          return part;
+        }
+
+        if (part && typeof part === "object" && "text" in part) {
+          return String((part as { text?: unknown }).text ?? "");
+        }
+
+        return "";
+      })
+      .join("\n")
+      .trim();
+  }
+
+  if (content && typeof content === "object" && "text" in content) {
+    return String((content as { text?: unknown }).text ?? "").trim();
+  }
+
+  return "";
+}
+
+class DefaultChatService implements ChatService {
+  constructor(private readonly deps: ChatServiceDependencies) {}
+
+  validate(payload: unknown): ChatValidationResult {
+    return validateChatPayload(payload);
+  }
+
+  async createChatCompletion(payload: ChatPayload): Promise<string> {
+    const messages = toLangChainMessages(
+      payload.messages,
+      this.deps.systemPrompt
+    );
+    const aiMessage = await this.deps.model.invoke(messages);
+    const content = extractContent(aiMessage.content);
+
+    if (!content) {
+      throw new EmptyAIResponseError();
+    }
+
+    return content;
+  }
+}
+
+export function createChatService(
+  deps?: Partial<ChatServiceDependencies>
+): ChatService {
+  const model = deps?.model ?? createGroqClient();
+  const systemPrompt = deps?.systemPrompt ?? process.env.SYSTEM_PROMPT;
+
+  return new DefaultChatService({ model, systemPrompt });
+}

--- a/simple-graphchain/groq-client.ts
+++ b/simple-graphchain/groq-client.ts
@@ -1,0 +1,28 @@
+import { ChatGroq } from "@langchain/groq";
+
+const DEFAULT_MODEL = process.env.GROQ_MODEL ?? "llama-3.3-70b-versatile";
+const DEFAULT_TEMPERATURE = Number.parseFloat(
+  process.env.GROQ_TEMPERATURE ?? "0"
+);
+
+function getGroqApiKey() {
+  const apiKey = process.env.GROQ_API_KEY?.trim();
+
+  if (!apiKey) {
+    throw new Error(
+      "Missing GROQ_API_KEY. Configúralo en el entorno o defínelo en el archivo .env."
+    );
+  }
+
+  return apiKey;
+}
+
+export function createGroqClient() {
+  return new ChatGroq({
+    model: DEFAULT_MODEL,
+    temperature: DEFAULT_TEMPERATURE,
+    apiKey: getGroqApiKey(),
+  });
+}
+
+export type GroqChatModel = ReturnType<typeof createGroqClient>;

--- a/simple-graphchain/main.ts
+++ b/simple-graphchain/main.ts
@@ -2,13 +2,9 @@ import "dotenv/config";
 import cors from "cors";
 import express, { type Request, type Response } from "express";
 import { pathToFileURL } from "url";
-import { z } from "zod";
-import { AIMessage, HumanMessage, SystemMessage, type BaseMessage } from "@langchain/core/messages";
-import { ChatGroq } from "@langchain/groq";
+import { createChatRouter } from "./chat-router.js";
+import { createChatService } from "./chat-service.js";
 
-const DEFAULT_MODEL = process.env.GROQ_MODEL ?? "llama-3.3-70b-versatile";
-const DEFAULT_TEMPERATURE = Number.parseFloat(process.env.GROQ_TEMPERATURE ?? "0");
-const SYSTEM_PROMPT = process.env.SYSTEM_PROMPT;
 const PORT = Number.parseInt(
   process.env.PORT ?? process.env.SERVER_PORT ?? "3000",
   10
@@ -16,86 +12,6 @@ const PORT = Number.parseInt(
 
 if (Number.isNaN(PORT)) {
   throw new Error("El puerto configurado no es un número válido.");
-}
-
-const messageSchema = z.object({
-  role: z.enum(["user", "assistant", "system"]).default("user"),
-  content: z.string().min(1, "El contenido no puede estar vacío."),
-});
-
-const chatPayloadSchema = z.object({
-  messages: z.array(messageSchema).min(1, "Se requiere al menos un mensaje."),
-});
-
-function getGroqApiKey() {
-  const apiKey = process.env.GROQ_API_KEY?.trim();
-
-  if (!apiKey) {
-    throw new Error(
-      "Missing GROQ_API_KEY. Configúralo en el entorno o defínelo en el archivo .env."
-    );
-  }
-
-  return apiKey;
-}
-
-const chatModel = new ChatGroq({
-  model: DEFAULT_MODEL,
-  temperature: DEFAULT_TEMPERATURE,
-  apiKey: getGroqApiKey(),
-});
-
-function toLangChainMessages(messages: Array<{ role: string; content: string }>) {
-  const formatted: BaseMessage[] = [];
-
-  if (SYSTEM_PROMPT) {
-    formatted.push(new SystemMessage(SYSTEM_PROMPT));
-  }
-
-  for (const message of messages) {
-    if (message.role === "assistant") {
-      formatted.push(new AIMessage(message.content));
-      continue;
-    }
-
-    if (message.role === "system") {
-      formatted.push(new SystemMessage(message.content));
-      continue;
-    }
-
-    formatted.push(new HumanMessage(message.content));
-  }
-
-  return formatted;
-}
-
-function extractContent(content: unknown): string {
-  if (typeof content === "string") {
-    return content.trim();
-  }
-
-  if (Array.isArray(content)) {
-    return content
-      .map((part) => {
-        if (typeof part === "string") {
-          return part;
-        }
-
-        if (part && typeof part === "object" && "text" in part) {
-          return String((part as { text?: unknown }).text ?? "");
-        }
-
-        return "";
-      })
-      .join("\n")
-      .trim();
-  }
-
-  if (content && typeof content === "object" && "text" in content) {
-    return String((content as { text?: unknown }).text ?? "").trim();
-  }
-
-  return "";
 }
 
 function createApp() {
@@ -108,35 +24,8 @@ function createApp() {
     res.json({ status: "ok" });
   });
 
-  app.post("/chat", async (req: Request, res: Response) => {
-    const parsed = chatPayloadSchema.safeParse(req.body);
-
-    if (!parsed.success) {
-      const issues = parsed.error.issues.map((issue) => issue.message);
-      res.status(400).json({ error: "Solicitud inválida", details: issues });
-      return;
-    }
-
-    try {
-      const messages = toLangChainMessages(parsed.data.messages);
-      const aiMessage = await chatModel.invoke(messages);
-      const content = extractContent(aiMessage.content);
-
-      if (!content) {
-        res.status(502).json({
-          error: "La respuesta de la IA está vacía.",
-        });
-        return;
-      }
-
-      res.json({ content });
-    } catch (error) {
-      console.error("Error al invocar el modelo:", error);
-      res.status(500).json({
-        error: "No se pudo obtener una respuesta de la IA.",
-      });
-    }
-  });
+  const chatService = createChatService();
+  app.use("/chat", createChatRouter(chatService));
 
   return app;
 }


### PR DESCRIPTION
## Summary
- crear un router de Express dedicado para el endpoint de chat que delega en el servicio
- encapsular la creación del cliente de Groq y permitir inyectarlo en el servicio de chat
- ajustar el arranque del servidor para utilizar el nuevo servicio y router

## Testing
- npm run start *(falla: falta el módulo `dotenv/config` en este entorno sin acceso a npm)*
- npx tsc --noEmit *(falla: la configuración del repositorio apunta a otra carpeta y no encuentra entradas)*

------
https://chatgpt.com/codex/tasks/task_e_68d04e24caac833383be108eaefc4e0f